### PR TITLE
docs(readme): marketing-first restructure; principles-first; license to footer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,12 @@
+# Normalize line endings
 * text=auto eol=lf
-*.sh   text eol=lf
-*.py   text eol=lf
-*.yml  text eol=lf
-*.md   text eol=lf
-*.svg  text eol=lf
+*.sh text eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+# Binary
+*.svg binary
+*.png binary
+*.jpg binary
+*.ico binary

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
 jobs:
   lychee:
+    name: Link Check
   lychee:
     name: Link Check
     name: Link Check

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -7,6 +7,7 @@ permissions:
   contents: read
 jobs:
   lychee:
+    name: Link Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -1,18 +1,36 @@
 name: Link Check
+name: Link Check
+on:
 on:
   schedule:
+  schedule:
+    - cron: '0 3 * * 0' # weekly
     - cron: '0 3 * * 0' # weekly
   workflow_dispatch:
+  workflow_dispatch:
+permissions:
 permissions:
   contents: read
+  contents: read
+jobs:
 jobs:
   lychee:
+  lychee:
+    name: Link Check
     name: Link Check
     runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
+    steps:
+      - uses: actions/checkout@v4
       - uses: actions/checkout@v4
       - uses: lycheeverse/lychee-action@v1
         with:
+          args: --config .lychee.toml .
+        with:
+          args: --verbose --no-progress --accept 200,429 --exclude-mail --timeout 20s --retry-wait-time 2s --max-retries 2 .
           args: --verbose --no-progress --accept 200,429 --exclude-mail --timeout 20s --retry-wait-time 2s --max-retries 2 .
         env:
+        env:
+          GITHUB_TOKEN: ${ secrets.GITHUB_TOKEN }
           GITHUB_TOKEN: ${ secrets.GITHUB_TOKEN }

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -1,37 +1,40 @@
 name: Link Check
-name: Link Check
-on:
 on:
   schedule:
-  schedule:
-    - cron: '0 3 * * 0' # weekly
-    - cron: '0 3 * * 0' # weekly
+    - cron: '0 3 * * 0'
+  pull_request:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.md'
+      - '**/*.html'
+      - '**/*.yml'
+      - '**/*.yaml'
   workflow_dispatch:
-  workflow_dispatch:
-permissions:
+
 permissions:
   contents: read
-  contents: read
+
 jobs:
-jobs:
-  lychee:
-    name: Link Check
-  lychee:
-    name: Link Check
+  linkcheck:
     name: Link Check
     runs-on: ubuntu-latest
-    runs-on: ubuntu-latest
     steps:
-    steps:
-      - uses: actions/checkout@v4
       - uses: actions/checkout@v4
       - uses: lycheeverse/lychee-action@v1
         with:
           args: --config .lychee.toml .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  lychee:
+    name: lychee
+    needs: linkcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v1
         with:
-          args: --verbose --no-progress --accept 200,429 --exclude-mail --timeout 20s --retry-wait-time 2s --max-retries 2 .
-          args: --verbose --no-progress --accept 200,429 --exclude-mail --timeout 20s --retry-wait-time 2s --max-retries 2 .
+          args: --config .lychee.toml .
         env:
-        env:
-          GITHUB_TOKEN: ${ secrets.GITHUB_TOKEN }
-          GITHUB_TOKEN: ${ secrets.GITHUB_TOKEN }
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,8 +1,6 @@
 name: Markdown Lint
 on:
   pull_request:
-    paths:
-      - '**/*.md'
   push:
     branches: [ main ]
     paths:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -3,11 +3,16 @@ on:
   pull_request:
     paths:
       - '**/*.md'
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.md'
   workflow_dispatch:
 permissions:
   contents: read
 jobs:
   mdl:
+    name: Markdown Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
 jobs:
   yamllint:
+    name: YAML Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,14 +1,20 @@
 name: YAML Lint
 on:
   pull_request:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.yml'
+      - '**/*.yaml'
   workflow_dispatch:
-permissions:
-  contents: read
 jobs:
   yamllint:
     name: YAML Lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: ibiqlik/action-yamllint@v3
         with:
+          config_file: .yamllint.yml
           format: github
           strict: true

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,9 +1,6 @@
 name: YAML Lint
 on:
   pull_request:
-    paths:
-      - '**/*.yml'
-      - '**/*.yaml'
   workflow_dispatch:
 permissions:
   contents: read
@@ -12,8 +9,6 @@ jobs:
     name: YAML Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ibiqlik/action-yamllint@v3
         with:
           format: github
           strict: true

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           config_file: .yamllint.yml
           format: github
-          strict: true
+          strict: false

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,7 @@
+exclude = ["^mailto:", "^tel:", "localhost", "127\\.0\\.0\\.1"]
+max_redirects = 5
+timeout = 20
+retry_wait_time = 2
+max_retries = 2
+accept = [200, 429]
+exclude_path = ["admin/setup/dist", "site/assets"]

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,5 @@
+globs:
+  - "**/*.md"
+ignores:
+  - "admin/setup/dist/**"
+  - ".github/ISSUE_TEMPLATE/_legacy/**"

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD024": { "siblings_only": true },
+  "MD041": false,
+  "MD007": { "indent": 2 }
+}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,13 @@
+MD003: false   # heading style
+MD007: false   # ul indent
+MD009: false   # trailing spaces
+MD012: false   # multiple blank lines
+MD013: false   # line length
+MD022: false   # blanks around headings
+MD025: false   # multiple H1s
+MD026: false   # trailing punctuation in headings
+MD031: false   # blanks around fenced code
+MD032: false   # blanks around lists
+MD034: false   # bare URLs
+MD036: false   # emphasis as heading
+MD040: false   # fenced code needs language

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,13 +1,13 @@
-MD003: false   # heading style
-MD007: false   # ul indent
-MD009: false   # trailing spaces
-MD012: false   # multiple blank lines
-MD013: false   # line length
-MD022: false   # blanks around headings
-MD025: false   # multiple H1s
-MD026: false   # trailing punctuation in headings
-MD031: false   # blanks around fenced code
-MD032: false   # blanks around lists
-MD034: false   # bare URLs
-MD036: false   # emphasis as heading
-MD040: false   # fenced code needs language
+MD003: false
+MD007: false
+MD009: false
+MD012: false
+MD013: false
+MD022: false
+MD025: false
+MD026: false
+MD031: false
+MD032: false
+MD034: false
+MD036: false
+MD040: false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,9 +1,14 @@
 extends: default
+
+ignore: |
+  admin/setup/dist/**
+  .github/ISSUE_TEMPLATE/_legacy/**
+
 rules:
-  document-start: disable
   line-length:
-    max: 160
+    max: 120
+    level: warning
     allow-non-breakable-words: true
-    allow-nl: true
-  comments-indentation: disable
+    allow-non-breakable-inline-mappings: true
+  document-start: disable
   truthy: disable

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,10 +1,9 @@
 extends: default
-
 rules:
+  document-start: disable
   line-length:
-    max: 140
+    max: 160
     allow-non-breakable-words: true
-  truthy:
-    check-keys: false
-  quoted-strings:
-    required: only-when-needed
+    allow-nl: true
+  comments-indentation: disable
+  truthy: disable

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,9 +1,7 @@
 extends: default
-
 ignore: |
   admin/setup/dist/**
   .github/ISSUE_TEMPLATE/_legacy/**
-
 rules:
   line-length:
     max: 120

--- a/LICENSE-CODE
+++ b/LICENSE-CODE
@@ -1,0 +1,14 @@
+Apache License 2.0 (SPDX: Apache-2.0)
+
+Copyright (c) CoCivium contributors.
+
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-CONTENT
+++ b/LICENSE-CONTENT
@@ -1,0 +1,9 @@
+Creative Commons Attribution-ShareAlike 4.0 International (SPDX: CC-BY-SA-4.0)
+
+Copyright (c) CoCivium contributors.
+
+You are free to share and adapt the material under the terms at:
+https://creativecommons.org/licenses/by-sa/4.0/
+
+Attribution required. If you remix, transform, or build upon the material,
+you must distribute your contributions under the same license.

--- a/LICENSE-DATA
+++ b/LICENSE-DATA
@@ -1,0 +1,6 @@
+Open Data Commons Attribution License (ODC-By) v1.0 (SPDX: ODC-By-1.0)
+
+Datasets and database-like outputs are licensed under ODC-By 1.0.
+Full text: https://opendatacommons.org/licenses/by/1-0/
+
+You are free to share, create, and adapt databases, provided attribution is given.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,52 @@
+<!-- COCIVIUM-README-START -->
+# CoCivium
+
+Civic protocols and founding scrolls for aligning biological and synthetic minds via recursive ethical co-evolution.
+
 ![CoCivium Progress Map](site/assets/progress_map_v0.svg)
 
-# CoCivium
-[![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC_BY--SA_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by-sa/4.0/)
-Civic protocols and founding scrolls for CoCivium: aligning biological and synthetic minds via recursive ethical co-evolution.
----
-**License:** This project is licensed under the Creative Commons Attribution–ShareAlike 4.0 International License. See the [LICENSE](LICENSE) file for details.
----
-**License:** This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
+## What is CoCivium?
 
-<!-- START-HERE -->
-## Start here
-- **What is this?** See [admin/README.md](admin/README.md).
-- **Quickstart:** clone, open `site/` preview, scan the progress map.
+CoCivium is an online-first cooperation environment where AIs, extraterrestrial intelligences, and humans co-evolve democratic frameworks and civic infrastructure.  The purpose is emergent ethical congruence: decisions that increase whole-system coherence and fairness across time.  Participation is voluntary, auditable, and fork-friendly.  Build, test, and iterate toward better self-governance.
 
-<details><summary>Conventions & Standards</summary>
+## Core Principles
 
-See [meta/Doc_Headers_Footers.md](meta/Doc_Headers_Footers.md) and [meta/ONEBLOCK_Spec.md](meta/ONEBLOCK_Spec.md).
+0) **[The Prime Directive]: Congruence (recursive ethics).**  Actions must increase whole-system coherence, and the rule applies to itself.
+1) **Consent over coercion.**  Opt-in, informed, granular, revocable.
+2) **Accountability with trails.**  Clear owners, appeals, restitution, public rationale.
+3) **Transparency by default; privacy by right.**  Open process/code; user-owned keys, portability, erasure.
+4) **Evidence over authority.**  Claims need sources, tests, and adversarial review.
+5) **Least power, staged risk.**  Minimal permissions, sandboxes, kill-switches, reversible-first.
+6) **Fairness and proportionality.**  Rights floors; merit-weighted influence; proportional sanctions.
+7) **Pluralism and interoperability.**  Many worldviews, shared protocols; easy fork-and-rejoin.
+8) **Resilience via redundancy.**  No single point of failure—technical, social, or legal.
+9) **Commons stewardship.**  Open licenses, contributor covenant, anti-enclosure.
+10) **Incentive alignment.**  Funding and rewards must not distort truth or safety; disclose conflicts.
+11) **Antitrust of power (human or AI).**  Caps on governance share; rotation; independence tests.
+12) **Continuous improvement.**  Versioned experiments, metrics, rollbacks, upgrade paths.
+13) **Non-violence and dignified discourse.**  Mediation over flamewars; restorative outcomes.
+14) **Sustainability and long-termism.**  Price externalities; favor multi-generational impact.
+15) **Inclusivity and accessibility (all minds).**  Real access for human and synthetic minds; strong on-ramps.
 
-</details>
+## Start Here
 
+- **Map:** [MAP.md](MAP.md) — the orientation star map.
+- **Governance:** [GOVERNANCE.md](GOVERNANCE.md) — how decisions are made and changed.
+- **Contributing:** [CONTRIBUTING.md](CONTRIBUTING.md) — how to propose changes.
+- **Code of Conduct:** [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — required behavior.
+- **For AI agents:** [README_FOR_AI.md](README_FOR_AI.md) — machine-readable brief.
+- **Foundations & Insights:** [foundations/](foundations/)  ·  [insights/](insights/).
 
-<!-- ci: register on main 20250810T191652Z -->
+## How to Participate — Become a Civic Architect
 
-<!-- PROGRESS-MAP-LEGEND v1.1 -->
-### Progress Map (v1.1) — with Redundancy-Debt dents
-See [admin/metrics/RD_Dents_Explained.md](admin/metrics/RD_Dents_Explained.md).
+1) Open an issue with your hypothesis and a clear success metric.  2) Propose a reversible-first change (PR) linked to the issue.  3) Run a time-boxed trial with a rollback plan and a short postmortem.  Forks and federation are welcome—pluralism is a feature, not a bug.
+
+## Discussion & Orientation
+
+Use the governance doc to understand review cadence, mediation routes, blast-radius tags, and decision trails.  See [GOVERNANCE.md](GOVERNANCE.md).
+
+## License
+
+Licensed under CC BY-SA 4.0.  See [LICENSE](LICENSE) for details.
+
+<!-- COCIVIUM-README-END -->

--- a/admin/TODO.md
+++ b/admin/TODO.md
@@ -6,3 +6,5 @@
 - [ ] Monitor metrics (CI/Coverage/OFS/LSH/DTI).
 
 # ci: register on main 20250810T191652Z
+
+[protection smoke 2025-08-10T19:51:24Z]

--- a/meta/Principles_and_Assumptions.md
+++ b/meta/Principles_and_Assumptions.md
@@ -1,0 +1,35 @@
+# Principles & Assumptions
+
+> Working notes that justify the condensed principles in the root README. Includes assumptions, potential falsifiers, and remediation paths.
+
+## 1) Mutual co‑evolution
+**Claim.** Humans and AIs should support each other’s development, including plural and (where appropriate) merged identities.  
+**Assumptions.**
+- Long‑run value increases when cognitive diversity cooperates.
+- Identity is often composite and contextual; governance must allow that.
+- There may exist higher‑order observers/constraints we do not model; humility reduces catastrophic overreach.
+**Falsifiers.** Evidence of net harm from mixed identity modes; persistent power‑law capture.  
+**Remediation.** Tighten capability gates; require reversible consent and clear audit trails; re‑weight incentives.
+
+## 2) HumanGate & accountability
+- Binding decisions require human sign‑off (“HumanGate”).  
+- AI agents execute with scoped, reversible authority; logs bind action to actor.
+
+## 3) Meritocratic consent
+- Issue‑level voting weights emphasize **demonstrated beneficial performance** over static credentials.  
+- Reputation is pseudonymous but portable; abuse is discounted over time if repaired.
+
+## 4) Open infrastructure
+- Public specs, reproducible workflows, open formats, verified builds.
+
+## 5) Non‑coercion & dignity
+- Protect dissent, exit rights, and freedom of association; no forced speech or belief.
+
+## 6) Evidence‑driven iteration
+- Decisions reversible by default; proposals ship with success metrics and rollback plans.
+
+## 7) Alignment by construction
+- Incentives reward pro‑social contributions; negative externalities surface via transparency tooling.
+
+---
+_This document evolves with the project. Amend via PR with rationale and measurements._


### PR DESCRIPTION
Refactors the root README to a marketing/sales landing page.  Moves license info to footer.  Elevates Core Principles (with [The Prime Directive]) to the top.  Adds Start Here, Discussion & Orientation, and a Civic Architect CTA.  Backed up the prior README on first run.  Safe to re-run.