### PR TITLE
Gatekeeper: require maintainer review (CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-admin/projects/* @rickballard
-admin/products/* @rickballard
+# Temporary gatekeeper: require a maintainer review for everything
+* @rickballard


### PR DESCRIPTION
Temporary while onboarding new contributors.