### PR TITLE
ops: migration status report

### DIFF
--- a/notes/migration_status.md
+++ b/notes/migration_status.md
@@ -1,0 +1,41 @@
+# Migration status — 2025-08-14
+
+## Canonical content
+* Insights: **20**
+* Sections:
+  * codex: **0**
+  * consent: **0**
+  * intent: **0**
+  * resolution: **0**
+  * ethos: **0**
+  * identity: **0**
+  * discussions: **0**
+  * amendments: **0**
+  * domains: **0**
+  * seed: **0**
+  * lexicon: **0**
+* Projects: **1**
+
+## Remaining items in `staging/_imported`
+* Total files: **259**
+* Top buckets (by file count):
+  1. admin/inbox — 52 files
+  2. admin/hold — 39 files
+  3. deprecated/holding — 21 files
+  4. projects/website — 6 files
+  5. admin/deprecated — 4 files
+  6. projects/godspawn — 3 files
+  7. projects/votingengine — 3 files
+  8. projects/beaxa — 2 files
+  9. projects/civiscan — 2 files
+  10. projects/entment — 2 files
+  11. projects/opename — 2 files
+  12. projects/outreach — 2 files
+  13. admin/deprecated_todo — 2 files
+  14. projects/academy — 2 files
+  15. discussions/Will_Civium_Be_Safe_for_Skeptics.md — 1 files
+
+## Next actions
+- [ ] Triage remaining staging/_imported buckets above.
+- [ ] Promote any still-relevant drafts into canonical sections, then delete the source drafts.
+- [ ] Keep CI ignoring legacy/** and staging/_imported/** to prevent noise.


### PR DESCRIPTION
Adds **notes/migration_status.md** with canonical counts and the top residual buckets under staging/_imported for triage.