### PR TITLE
chore: CSV LF guard + normalize (20250814_2101)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 *.yml  text eol=lf
 *.yaml text eol=lf
 *.py   text eol=lf
+
+*.csv  text eol=lf


### PR DESCRIPTION
Adds '*.csv text eol=lf' and re-stages CSVs in staging/_incoming/uploads/20250814_2101.