### PR TITLE
Icons: dark/light-aware line icons

### DIFF
--- a/assets/icons/broken.svg
+++ b/assets/icons/broken.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img"><style>:root{color-scheme:light dark}@media(prefers-color-scheme:dark){svg{color:#e5e7eb}}@media(prefers-color-scheme:light){svg{color:#111827}}path,circle,rect,line,polyline,polygon{stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}</style>
+  <path d="M4 4h16v16H4z"/>
+  <path d="M9 4l3 5l-2 3l3 3l-2 5"/>
+</svg>
+

--- a/assets/icons/coevolve.svg
+++ b/assets/icons/coevolve.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img"><style>:root{color-scheme:light dark}@media(prefers-color-scheme:dark){svg{color:#e5e7eb}}@media(prefers-color-scheme:light){svg{color:#111827}}path,circle,rect,line,polyline,polygon{stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}</style>
+  <path d="M4 8c2-3 6-3 8 0s6 3 8 0"/>
+  <path d="M4 16c2 3 6 3 8 0s6-3 8 0"/>
+</svg>
+

--- a/assets/icons/feels.svg
+++ b/assets/icons/feels.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img"><style>:root{color-scheme:light dark}@media(prefers-color-scheme:dark){svg{color:#e5e7eb}}@media(prefers-color-scheme:light){svg{color:#111827}}path,circle,rect,line,polyline,polygon{stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}</style>
+  <path d="M12 2a10 10 0 1 1 0 20a10 10 0 0 1 0-20z"/>
+  <path d="M8.5 15.5l3.2-7.2l7.2-3.2l-3.2 7.2l-7.2 3.2z"/>
+  <path d="M12 12l-1 -1"/>
+</svg>
+

--- a/assets/icons/for-you.svg
+++ b/assets/icons/for-you.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img"><style>:root{color-scheme:light dark}@media(prefers-color-scheme:dark){svg{color:#e5e7eb}}@media(prefers-color-scheme:light){svg{color:#111827}}path,circle,rect,line,polyline,polygon{stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}</style>
+  <path d="M7 13l3 3a2 2 0 0 0 3 0l4-4"/>
+  <path d="M6 9l3 3"/>
+  <path d="M15 9l3 3"/>
+  <path d="M4 12l3-3a2 2 0 0 1 2-1h2a2 2 0 0 1 2 1l3 3"/>
+</svg>
+

--- a/assets/icons/governments.svg
+++ b/assets/icons/governments.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img"><style>:root{color-scheme:light dark}@media(prefers-color-scheme:dark){svg{color:#e5e7eb}}@media(prefers-color-scheme:light){svg{color:#111827}}path,circle,rect,line,polyline,polygon{stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}</style>
+  <path d="M4 6h16"/>
+  <path d="M7 6v12"/>
+  <path d="M12 6v12"/>
+  <path d="M17 6v12"/>
+  <path d="M5 20h14"/>
+  <path d="M6 6c0-2 12-2 12 0"/>
+</svg>
+

--- a/assets/icons/life.svg
+++ b/assets/icons/life.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img"><style>:root{color-scheme:light dark}@media(prefers-color-scheme:dark){svg{color:#e5e7eb}}@media(prefers-color-scheme:light){svg{color:#111827}}path,circle,rect,line,polyline,polygon{stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}</style>
+  <path d="M12 3c2 2 2 3.5 0 5.5-2-2-2-3.5 0-5.5z"/>
+  <path d="M10 10h4"/>
+  <path d="M12 10v7"/>
+  <path d="M9 21h6"/>
+  <path d="M10.5 17h3"/>
+</svg>
+

--- a/assets/icons/solutions.svg
+++ b/assets/icons/solutions.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img"><style>:root{color-scheme:light dark}@media(prefers-color-scheme:dark){svg{color:#e5e7eb}}@media(prefers-color-scheme:light){svg{color:#111827}}path,circle,rect,line,polyline,polygon{stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}</style>
+  <path d="M10 14a4 4 0 1 1 0-8a4 4 0 0 1 0 8z"/>
+  <path d="M10 10h8"/>
+  <path d="M18 10v3"/>
+  <path d="M16 10v2"/>
+</svg>
+

--- a/assets/icons/until.svg
+++ b/assets/icons/until.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img"><style>:root{color-scheme:light dark}@media(prefers-color-scheme:dark){svg{color:#e5e7eb}}@media(prefers-color-scheme:light){svg{color:#111827}}path,circle,rect,line,polyline,polygon{stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}</style>
+  <path d="M6 3h12"/>
+  <path d="M6 21h12"/>
+  <path d="M7 3c0 4 10 4 10 8s-10 4-10 8"/>
+  <path d="M17 3c0 4-10 4-10 8s10 4 10 8"/>
+</svg>
+


### PR DESCRIPTION
Injects prefers-color-scheme CSS; removes hard fills; consistent 20×20 line glyphs.