### PR TITLE
README/Icons hotfix: Why–Who–How + sanitize & rename icons (fix black squares)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ NOTE TO EDITORS (offline-safe):
 ## We The People, Empowered.
 <img src="./assets/icons/life.svg" alt="LIFE" width="20" height="20" />&nbsp; **LIFE:** Democracies are in decline as elites gain wealth and power, as entire populations are manipulated by lies, propaganda and information ops, as geopolitical fragmentation brings policy volatility, economic wars and military invasions.  Are governments supposed to serve, or be served?  Did the word "dignity" fall out of our Constitution?
 
+**Why:** Democracy needs to be rescued. Digital life is faster than law. Guardrails<<link>> must scale with agency.
+**Who:** Humans and AIs who accept consent-first rules. Temporary stewards/founders, federated ASAP.
+**How:** CoConstitution, process specs, and adapters that embed dignity into civic tools.
+
+<img src="./assets/icons/life.svg" alt="LIFE" width="20" height="20" />&nbsp; **LIFE:** Democracies are in decline as elites gain wealth and power, as entire populations are manipulated by lies, propaganda and information ops, as geopolitical fragmentation brings policy volatility, economic wars and military invasions.  Are governments supposed to serve, or be served?  Did the word "dignity" fall out of our Constitution?
+
 <img src="./assets/icons/feels.svg" alt="FEELS" width="20" height="20" />&nbsp; **FEELS:** It's easy to accept that resistance is futile, or that half the country has lost the plot, captured by partisan hostility and tribal reflexes.  Our hearts ache for what is right, for a community anchored by fair processes, evidential truth, ethical norms and structured rights.
 
 <img src="./assets/icons/broken.svg" alt="BROKEN" width="20" height="20" />&nbsp; **BROKEN:** Some are fighting back, using rage against rage, hate versus hate, but multiplying damage.  Their faith in institutions lies crippled by exclusion and disrespect, their voices ignored while policies harden.  But anger, like an "insanity tsunami"**, becomes more coercion.
@@ -35,7 +41,7 @@ NOTE TO EDITORS (offline-safe):
 
 <img src="./assets/icons/governments.svg" alt="GOVERNMENTS" width="20" height="20" />&nbsp; **GOVERNMENTS:** Many public institutions rely on civic architecture developed before typewriters.  Few of their policies can be evolved by those they impact, and they continue to fall behind as society offers biotech brains, neural interfaces, ubiquitous networks and augmented reality; a very different society, existential to humanity, yet so unregulated it risks lawless chaos.
 
-<img src="./assets/icons/coevolve.svg" alt="CoEvolve" width="20" height="20" />&nbsp; **CoEvolve:** Here we create structures and processes for the age of AI, where humans and AIs co-govern at a speed and scale that allows governance to react, iterate and continually improve.  As AI's achieve agency, as Artificial General Intelligence reaches its singularity, we more urgently require effective guardrails to keep power accountable (e.g., acountability<<lik>>, transparency<<link>>, reversibility<<link>>).
+<img src="./assets/icons/coevolve.svg" alt="CoEvolve" width="20" height="20" />&nbsp; **CoEvolve:** Here we create structures and processes for the age of AI, where humans and AIs co-govern at a speed and scale that allows governance to react, iterate and continually improve.  As AI's achieve agency, as Artificial General Intelligence reaches its singularity, we more urgently require effective guardrails to keep power accountable (e.g., accountability<<link>>, transparency<<link>>, reversibility<<link>>).
 
 <img src="./assets/icons/solutions.svg" alt="SOLUTIONS" width="20" height="20" />&nbsp; **SOLUTIONS:** Our job here, as an open source community, is to **Protect Prove, and Play.  Protect:** rescue democracy from abuse of power, (e.g., evolve access controls, audit trails, adversarial-testing program).  **Prove:** keep truth verifiable in an age of synthesis, (e.g., evolve verifiable claims, signed evidence bundles, provenance check<<link>>).  **Play:** make the rules fair for everyone, including human–AI teams, (e.g., evolve fair-use rules, symmetric obligations for human–AI teams, appeal paths).
 

--- a/assets/icons/broken-line.svg
+++ b/assets/icons/broken-line.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img" fill="none">
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M4 4h16v16H4z"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M9 4l3 5l-2 3l3 3l-2 5"/>
+</svg>

--- a/assets/icons/broken.svg
+++ b/assets/icons/broken.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img">
-  <path d="M4 4h16v16H4z"/>
-  <path d="M9 4l3 5l-2 3l3 3l-2 5"/>
-</svg>

--- a/assets/icons/coevolve-line.svg
+++ b/assets/icons/coevolve-line.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img" fill="none">
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M4 8c2-3 6-3 8 0s6 3 8 0"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M4 16c2 3 6 3 8 0s6-3 8 0"/>
+</svg>

--- a/assets/icons/coevolve.svg
+++ b/assets/icons/coevolve.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img">
-  <path d="M4 8c2-3 6-3 8 0s6 3 8 0"/>
-  <path d="M4 16c2 3 6 3 8 0s6-3 8 0"/>
-</svg>

--- a/assets/icons/feels-line.svg
+++ b/assets/icons/feels-line.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img" fill="none">
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M12 2a10 10 0 1 1 0 20a10 10 0 0 1 0-20z"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M8.5 15.5l3.2-7.2l7.2-3.2l-3.2 7.2l-7.2 3.2z"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M12 12l-1 -1"/>
+</svg>

--- a/assets/icons/feels.svg
+++ b/assets/icons/feels.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img">
-  <path d="M12 2a10 10 0 1 1 0 20a10 10 0 0 1 0-20z"/>
-  <path d="M8.5 15.5l3.2-7.2l7.2-3.2l-3.2 7.2l-7.2 3.2z"/>
-  <path d="M12 12l-1 -1"/>
-</svg>

--- a/assets/icons/for-you-line.svg
+++ b/assets/icons/for-you-line.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img" fill="none">
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M7 13l3 3a2 2 0 0 0 3 0l4-4"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M6 9l3 3"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M15 9l3 3"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M4 12l3-3a2 2 0 0 1 2-1h2a2 2 0 0 1 2 1l3 3"/>
+</svg>

--- a/assets/icons/for-you.svg
+++ b/assets/icons/for-you.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img">
-  <path d="M7 13l3 3a2 2 0 0 0 3 0l4-4"/>
-  <path d="M6 9l3 3"/>
-  <path d="M15 9l3 3"/>
-  <path d="M4 12l3-3a2 2 0 0 1 2-1h2a2 2 0 0 1 2 1l3 3"/>
-</svg>

--- a/assets/icons/governments-line.svg
+++ b/assets/icons/governments-line.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img" fill="none">
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M4 6h16"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M7 6v12"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M12 6v12"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M17 6v12"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M5 20h14"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M6 6c0-2 12-2 12 0"/>
+</svg>

--- a/assets/icons/governments.svg
+++ b/assets/icons/governments.svg
@@ -1,8 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img">
-  <path d="M4 6h16"/>
-  <path d="M7 6v12"/>
-  <path d="M12 6v12"/>
-  <path d="M17 6v12"/>
-  <path d="M5 20h14"/>
-  <path d="M6 6c0-2 12-2 12 0"/>
-</svg>

--- a/assets/icons/life-line.svg
+++ b/assets/icons/life-line.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img" fill="none">
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M12 3c2 2 2 3.5 0 5.5-2-2-2-3.5 0-5.5z"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M10 10h4"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M12 10v7"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M9 21h6"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M10.5 17h3"/>
+</svg>

--- a/assets/icons/life.svg
+++ b/assets/icons/life.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img">
-  <path d="M12 3c2 2 2 3.5 0 5.5-2-2-2-3.5 0-5.5z"/>
-  <path d="M10 10h4"/>
-  <path d="M12 10v7"/>
-  <path d="M9 21h6"/>
-  <path d="M10.5 17h3"/>
-</svg>

--- a/assets/icons/solutions-line.svg
+++ b/assets/icons/solutions-line.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img" fill="none">
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M10 14a4 4 0 1 1 0-8a4 4 0 0 1 0 8z"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M10 10h8"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M18 10v3"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M16 10v2"/>
+</svg>

--- a/assets/icons/solutions.svg
+++ b/assets/icons/solutions.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img">
-  <path d="M10 14a4 4 0 1 1 0-8a4 4 0 0 1 0 8z"/>
-  <path d="M10 10h8"/>
-  <path d="M18 10v3"/>
-  <path d="M16 10v2"/>
-</svg>

--- a/assets/icons/until-line.svg
+++ b/assets/icons/until-line.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img" fill="none">
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M6 3h12"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M6 21h12"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M7 3c0 4 10 4 10 8s-10 4-10 8"/>
+  <path stroke="#9CA3AF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" fill="none" d="M17 3c0 4-10 4-10 8s10 4 10 8"/>
+</svg>

--- a/assets/icons/until.svg
+++ b/assets/icons/until.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img">
-  <path d="M6 3h12"/>
-  <path d="M6 21h12"/>
-  <path d="M7 3c0 4 10 4 10 8s-10 4-10 8"/>
-  <path d="M17 3c0 4-10 4-10 8s10 4 10 8"/>
-</svg>


### PR DESCRIPTION
• Replace hero paragraph with 3-line Why/Who/How.\n• Fix typos (Few **of** / **continue** to / institutions / accountability<<link>>).\n• Remove stray '**' after acrostic labels.\n• Rename icons to *-line.svg* and sanitize to stroke-only (no fills/backgrounds) to eliminate black squares; add cache-bust.\n\nThis supersedes earlier partial PRs.