### PR TITLE
README: canon ship (hero kept; dignified layout + crest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p>(for AI-Enabled "Hybrid Society")</em></p>
   <p>
     <img src="./assets/hero/quote-960w.png"
-         alt="“Government of the people…” — Abraham Lincoln, Gettysburg Address (1863)"
+         alt="ΓÇ£Government of the peopleΓÇªΓÇ¥ ΓÇö Abraham Lincoln, Gettysburg Address (1863)"
          width="960" />
   </p>
 
@@ -25,7 +25,7 @@ We need guardrails that scale with agency, regardless whether AIs become souls, 
 <img src="./assets/icons/for-you-line.svg" alt="" width="20" height="20" />&nbsp;&nbsp; **WHO** : Humans, AIs, and hybrid minds must cooperate to rebuild consent-first "hybrid societies".  Stop shouting into the wind and help defend Democracy, tame the singularity, and fix the world.  Join debates, agree rules, then ship them out, ready to work.
 
 <blockquote>
-  <p><em>"Self-governance doesn't happen on its own"</em> — Rick, a temporary repo steward.</p>
+  <p><em>"Self-governance doesn't happen on its own"</em> ΓÇö Rick, a temporary repo steward.</p>
 </blockquote>
 
 <img src="./assets/icons/how-line.svg" alt="" width="20" height="20" />&nbsp;&nbsp; **HOW** : (1) Listen widely to everyday people and experts, (2) Help everyone co-evolve an open, ever-green CoConstitution, (3) Run fast policy loops, (4) Ensure evidence beats bullshite, (5) Use functional ethics and blockchain accountability.  
@@ -35,14 +35,14 @@ More How : This Github repo aggregates and preserves ALL public wisdom, turning 
 **Contribute via any input channel:**
 
 - Use [ChatGPT] (or your preferred AI) to discuss and then vibe-code a civic solution Pull Request (PR).  
-  _Starter prompt:_ “Begin an ideas session for **CoCivium** and help me vibe-code pull requests for `rickballard/CoCivium`.”  
-- Use GitHub directly, or via our workflow accelerator [⚡ RepoAccelerator].  
+  _Starter prompt:_ ΓÇ£Begin an ideas session for **CoCivium** and help me vibe-code pull requests for `rickballard/CoCivium`.ΓÇ¥  
+- Use GitHub directly, or via our workflow accelerator [ΓÜí RepoAccelerator].  
 - Partner through [GroupBuild],  [InSeed], or others, to preserve **your good ideas**, or to open a PR.  
 - Join [CoCivium chats].  
 - Fork this repo to friendly-compete.
 
 [ChatGPT]: https://chatgpt.com/
-[⚡ RepoAccelerator]: tools/repo-accelerator/README.md "Quick-start scripts, templates, and checks"
+[ΓÜí RepoAccelerator]: tools/repo-accelerator/README.md "Quick-start scripts, templates, and checks"
 [GroupBuild]: https://www.groupbuild.org
 [InSeed]: https://www.inseed.com
 [CoCivium chats]: https://cocivium.org/chats
@@ -57,128 +57,146 @@ More How : This Github repo aggregates and preserves ALL public wisdom, turning 
 
 <img src="./assets/icons/until-line.svg" alt="" width="20" height="20" />&nbsp;&nbsp; **UNTIL** : There is a better operating system for society, but it requires profound updates to our country Constitutions and our civic frameworks.  CoCivium's CoConstitution (The Cognocarta Consenti) is a baseline anyone can adopt and evolve, for free, no strings attached.  
 
-<img src="./assets/icons/governments-line.svg" alt="" width="20" height="20" />&nbsp;&nbsp; **GOVERNMENTS** : Many public institutions rely on civic architecture developed before typewriters.  Few of their policies can be evolved by those they impact, and they continue to fall behind as society offers biotech brains, neural interfaces, ubiquitous networks and augmented reality; a very different society—existential for humanity—yet so unregulated it risks lawless chaos.  
+<img src="./assets/icons/governments-line.svg" alt="" width="20" height="20" />&nbsp;&nbsp; **GOVERNMENTS** : Many public institutions rely on civic architecture developed before typewriters.  Few of their policies can be evolved by those they impact, and they continue to fall behind as society offers biotech brains, neural interfaces, ubiquitous networks and augmented reality; a very different societyΓÇöexistential for humanityΓÇöyet so unregulated it risks lawless chaos.  
 
 <img src="./assets/icons/coevolve-line.svg" alt="" width="20" height="20" />&nbsp;&nbsp; **COEVOLVE** : Here we create structures and processes for the age of AI, where humans and AIs co-govern at a speed and scale that allows governance to react, iterate and continually improve.  As AIs achieve agency, and as Artificial General Intelligence approaches singularity, we more urgently require effective guardrails to keep power accountable (the triad is accountability, transparency, reversibility).  
 
-<img src="./assets/icons/solutions-line.svg"   alt="" width="20" height="20" />&nbsp;&nbsp; **SOLUTIONS** : Our job here is to <strong>Protect, Prove, Play</strong>. So when we say <strong>Protect</strong> we keep power accountable (access controls, audit trails, red-team/bug-bash); <strong>Prove</strong> makes claims verifiable (trusted-source credentials, signed evidence bundles, provenance checks); <strong>Play</strong> ensures fair rules for people and human–AI teams (ethical norms, symmetric obligations, clear appeals).  
+<img src="./assets/icons/solutions-line.svg"   alt="" width="20" height="20" />&nbsp;&nbsp; **SOLUTIONS** : Our job here is to <strong>Protect, Prove, Play</strong>. So when we say <strong>Protect</strong> we keep power accountable (access controls, audit trails, red-team/bug-bash); <strong>Prove</strong> makes claims verifiable (trusted-source credentials, signed evidence bundles, provenance checks); <strong>Play</strong> ensures fair rules for people and humanΓÇôAI teams (ethical norms, symmetric obligations, clear appeals).  
 
 <img src="./assets/icons/for-you-line.svg"     alt="" width="20" height="20" />&nbsp;&nbsp; **FOR YOU** : If you can picture society working better, or if you can test ideas against evidence, you already qualify as a civic architect for CoCivium.  Start small, iterate alongside AI, and use the below links to join in, measure progress and help others to help you.  
 
 ---
 
-## Quick Links
+# Cognocarta Consenti (CC)
+<img align="right" src="./assets/cc/cc-crest.svg" alt="Cognocarta Consenti crest" width="150">
 
-* [Start Here](#start-here)
-* [How To Help](#contributing)
-* [Current Status](#status-today)
-* [Performance and KPIs](#two-eyes-snapshot)
-* [CoConstitution (Cognocarta Consenti)](#coconstitution-cognocarta-consenti)
-* [Strategy Roadmap](#roadmap)
-* [Housekeeping](#housekeeping)
-* [License](#license)
+**Mission:** Build the **living constitution for digital society**—borderless, people-first, and **directly evolvable by anyone who cares**.
 
----
+**Project:** **CoCivium** is the open-source community that **writes, tests, and ships the CC**—plus the policies, processes, and tools that keep **hybrid life (physical + digital)** **democratic, equitable, and aligned** with human values.
 
-## Start Here
+> If you can read this page, you’re qualified to help. No coding or civics degree required.
 
-1. Read the **Preamble** to the CoConstitution (Cognocarta Consenti).  *(Repo-relative link; will resolve after commit.)*
-[link placeholder → ./charter/Cognocarta_Consenti_Preamble.md]`
-2. Skim the **Implementation Documents** for structure and amendment paths.
-[link placeholder → ./constitution/Operating_Constitution.md]`
-3. Browse the **Process Spec (CPS)** to see how proposals → deliberation → voting → execution flows.
-[link placeholder → ./specs/Process_Spec.md]`
-4. Try the **Decision Log Viewer**.
-[link placeholder → ./apps/decision-log/README.md]`
-
-Offline editing?  These files may not yet exist.  Placeholders resolve as files are committed.
-
----
-
-## How To Help
-
-* Read **CONTRIBUTING.md**.
-* File an issue tagged `domain`, `product`, `ops`, `ci`, `wiki`, `content`, `refactor`.
-* All merges pass through **HumanGate** for now.  Stewardship will decentralize as CoCivAI matures.
-
-*Quickstart scripts are PowerShell-first, with GitHub CLI helpers.  See `admin/setup/`.*
-
----
-
-## Current Status (by most active)
-
-<!-- GITHUB_ONLY: begin -->
+<div align="center"><sub>· · ·</sub></div>
 
 <details>
-  <summary>📦 Release / Site / CI (expand)</summary>
+<summary><strong>Contents</strong> (click to expand)</summary>
 
-* Latest release: `[placeholder → ./releases/latest]`
-* Website: `[placeholder → https://cocivium.org]`
-* CI status page: `[placeholder → ./actions]`
-
-</details>
-<!-- GITHUB_ONLY: end -->
-
-* What exists now: seed docs, early specs, repo scaffolding.
-* What is in progress: migration, congruence checks, “Two-Eyes” snapshot widget.
-* What is next: pilots, adapters, contributor onboarding.
-
----
-
-## Performance
-
-![Two-Eyes Status — replace with ./assets/status/two-eyes.png](./assets/status/two-eyes.png "If missing, this is a placeholder visualization.")
-
-*Legend:* Left eye = **Document quality & coherence**.  Right eye = **Operational readiness & adoption**.  Each iris ring tracks a dimension (CI, Coverage, OFS, LSH, DTI, Throughput, LT(inv), EE).  Replace the image with an auto-generated chart when wiring CI.
-
----
-
-## CoConstitution (Cognocarta Consenti)
-
-* **Purpose.** A consent-first constitutional core meant to be adopted alongside, not over, existing constitutions.
-* **Lineage.** Drafted by the CoCivium community; versioned and amendable via transparent process.
-* **Versioning.** `cc-v1`, `cocivop-v0.1`, `cocivproc-v0.1.0` (machine tags) with human aliases on site.
-
-> **Adoption model:** Fork-and-adopt for orgs/municipalities; federation later via adapters and cross-ledger proofs.
-
----
-
-## Strategy Roadmap
-
-* **Short:**  Migration finish; CI for congruence/hash/gibberlink checks; PR previews.
-* **Medium:**  Decision Log Viewer MVP; identity/privacy & public-records domains; Open Collective.
-* **Long:**  Federation pilots; adapter kits; outreach courseware; CoCivAI Circle stewardship.
-
----
-
-## Housekeeping
-
-* **Repo map:**  `README → Start Here → Quickstart`.
-* **Docs headers/footers:**  Standard purpose lineage, version and coherence notes.
-* **Brand note:**  Ensure assets live under `./assets/` with SVG + PNG fallbacks.
-
-**Graphics placeholders to replace on commit:**
-
-* `./assets/hero/hero.jpg` — landing hero.
-* `./assets/status/two-eyes.png` — status snapshot.
-* `./assets/badges/*.svg` — issues, PRs, CI, license, release.
-
----
-
-## License
-
-Apache-2.0 unless noted otherwise.  See `LICENSE`.
-
----
-
-<!-- EDITOR NOTES (safe to keep offline)
-  - Keep two spaces after periods in prose.
-  - Preserve top-of-fold “LIFE/FEELS/BROKEN/UNTIL/GOVERNMENTS/COEVOLVE/SOLUTIONS/FOR YOU” acrostic.
-  - When committing, verify links and replace placeholders.
--->
----
-<details>
-  <summary><small>About the category & our stance</small></summary>
-  <small>CoCivium is one implementation of an open pattern where <strong>individuals</strong> turn ideas into adoptable policy/standards packs.  The pattern is illustrated in our <a href="https://cocivium.org/map">Master Influence Flow Diagram (MIFD)</a>.  We welcome compatible forks and independent competitors, aiming for interoperable tooling and datasets so multiple platforms can converge as society learns what works.  Organizations do not govern CoCivium; they are recipients and venues to be influenced.  One person—optionally working with their AI—counts as one voice.  We continue to debate how an AI, an AI-collective like CoCivAI, or a post-identity AGI, should be fairly treated as a CoCivite, when it/they present as independent voice(s)</small>
+- <a href="#why-now-plain-language">Why now</a>
+- <a href="#what-the-cc-is">What the CC is</a>
+- <a href="#from-idea-to-impact-at-a-glance">From idea to impact</a>
+- <a href="#join-in-no-expertise-needed">Join in</a>
+- <a href="#the-two-eyes-model-citizen--system">The “Two Eyes” model</a>
+- <a href="#ground-rules-the-cocivium-pledge">Ground rules</a>
+- <a href="#start-here-quick-links">Start here</a>
+- <a href="#governance--continuity">Governance & continuity</a>
+- <a href="#inspiration--onboarding-for-humans-first">Inspiration / Onboarding</a>
 </details>
 
+---
+
+## Why now (plain language)
+
+- **Analog rules in a digital era.** Yesterday’s constitutions weren’t built for instant, global coordination.  
+- **Platforms act like public squares—without public safeguards.** A few companies set the rules and recourse.  
+- **Attention beats trust.** Outrage spreads; nuance stalls.  
+- **Participation is hard.** Jargon and gatekeeping keep most people out.  
+- **Good ideas die in threads.** We lack a clear path from **voice → draft → decision → action → accountability**.
+
+**The CC’s promise:** a shared, evolvable framework that communities can adopt, adapt, and audit.
+
+---
+
+## What the CC is
+
+- A **set of shared declarations** (promises, protocols, and rights) for how we listen, decide, and act—together.  
+- A **practical playbook** (patterns, templates, guardrails) any community can reuse.  
+- A **living document**: updated like good software—proposed, reviewed, improved **in the open**.
+
+**Read next:**  
+- [CC Preamble](./docs/cc/PREAMBLE.md) *(placeholder)*  
+- [CC Overview](./docs/cc/OVERVIEW.md) *(placeholder)*  
+- [CC Declarations Index](./docs/cc/DECLARATIONS.md) *(placeholder)*
+
+---
+
+## From idea to impact (at a glance)
+
+**voice → draft → review → decision → action → accountability**
+
+Start with an [Idea](../../issues/new/choose) — or ask your AI to open one using our [RepoAccelerator](./admin/tools/repo-accelerator/README.md) *(placeholder)*. When ready, open a **post** (pull request). That’s it. The rest you’ll learn as you go.
+
+*Details later:* see [Process Overview](./docs/process/OVERVIEW.md) *(placeholder)*.
+
+---
+
+## Join in (no expertise needed)
+
+**Bring your AI.** Seed it with [RepoAccelerator](./admin/tools/repo-accelerator/README.md) *(placeholder)* and ask it to draft issues or posts with you.
+
+**2 minutes — Say hi**  
+Open **Issues → New** → title: “Hello CoCivium”. One line about what you care about—locally or online.  
+*Or ask your AI to open it for you using our template.*
+
+**10 minutes — Share an idea**  
+Open an **Idea Issue** with a clear problem and a smallest useful change.  
+*Ask your AI to generate it from a paragraph of notes.*
+
+**30–60 minutes — Start a post (PR)**  
+Edit a page that needs love or add a note under `/proposals/`. Submit a **post**.  
+*Ask your AI to turn your issue into a PR and fill the template.*
+
+**Everything stays reversible.** Small steps, merged often.
+
+---
+
+## The “Two Eyes” model (citizen × system)
+
+We design governance that sees with **two eyes**:
+- **Eye 1: Citizens** — lived experience, local context, moral intuitions.  
+- **Eye 2: Systems** — data, constraints, impact analysis, safety.
+
+Together they give us **depth perception**—humane and workable decisions.
+
+![Two Eyes Diagram](./assets/diagrams/two-eyes.svg "Two Eyes: citizen + system co-vision") *(placeholder image)*
+
+---
+
+## Ground rules (The CoCivium Pledge)
+
+**Civility. Clarity. Curiosity. Consent. Credit.**  
+Disagree without demeaning, explain like to a neighbor, assume good faith, signal big changes early, attribute ideas.
+
+- [Code of Conduct](./CODE_OF_CONDUCT.md) *(placeholder)*  
+- [Contribution Guide](./CONTRIBUTING.md) *(placeholder)*  
+- [Maintainer Guide](./MAINTAINERS.md) *(placeholder)*
+
+---
+
+## Start here (quick links)
+
+- 📣 **New Idea →** [Open an issue](../../issues/new/choose) *(placeholder)*  
+- ✍️ **Start a post →** [Edit this file](../../edit/main/README.md) or create `/proposals/your-idea.md`  
+- 🧭 **CC Declarations →** [Index](./docs/cc/DECLARATIONS.md) *(placeholder)*  
+- 🧰 **RepoAccelerator →** [Set up your AI](./admin/tools/repo-accelerator/README.md) *(placeholder)*  
+- 🌐 **CoCivium.org →** https://CoCivium.org *(placeholder site)*
+
+---
+
+## Governance & continuity
+
+- **License:** [LICENSE](./LICENSE) *(placeholder)*  
+- **Governance:** [GOVERNANCE.md](./GOVERNANCE.md) *(includes decision process & roles)*  
+- **Stewardship & Continuity:** [CONTINUITY.md](./CONTINUITY.md) *(“if Rick gets hit by a bus” plan: key holders, backups, hand-off procedures)*  
+- **Security & Safety:** [SECURITY.md](./SECURITY.md) *(vuln reporting, escalation paths)*
+
+---
+
+## Inspiration / Onboarding for humans first
+
+- **Being Noname** — a gentle, human-centric onramp to CoCivium’s spirit and practice.  
+  → [Read the essay](./docs/onboarding/Being-Noname.md) *(placeholder)*
+
+- **FAQ** — short answers to common “Do I need to code?” and “What if I only have 5 minutes?” questions.  
+  → [Read the FAQ](./docs/FAQ.md) *(placeholder)*
+
+---


### PR DESCRIPTION
Preserves the existing top hero (spinning globe + quote). Introduces a clearer, more dignified structure: right-aligned crest, expandable Contents, improved callouts, SVG Two-Eyes diagram, and polished quick-start links. No functional changes outside presentation.