### PR TITLE
docs(readme): hero-first; quick-links tidy; small-print ages note

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 - **CC Declarations:** see the index
 
 
+<p align='center'>
+  <img src='assets/hero/hero.gif' alt='Globe animation'>
+</p>
+
+<p align='center'>
+  <img src='assets/hero/quote-960w.png'
+       srcset='assets/hero/quote-960w.png 1x, assets/hero/quote-960w@2x.png 2x'
+       alt='Quote' width='960'>
+</p>
+
 ## Fix The World.
 
 <img src="./assets/icons/broken-line.svg" alt="" width="20" height="20" />&nbsp;&nbsp; **WHY**  
@@ -165,6 +175,7 @@ Disagree without demeaning, explain like to a neighbor, assume good faith, signa
 
 Anyone can help co-evolve how we self-govern digital society—within age-appropriate guardrails and clear consent. Start with [Being Noname](admin/outreach/KickOpenAI/Posts/being_noname_insert.md), then try a tiny contribution: fix a typo, start a post (PR), or ask a question.
 <!-- cocivium:all-ages:end -->
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,3 @@
-### Start here
-
-- **New idea:** Open an issue
-- **Start a post:** Edit this file or add `/proposals/your-idea.md`
-- **Being Noname:** a bedtime story for kids who want to make a name for themselves. ([Read the story](stories/being-noname.md))
-- **CC Declarations:** see the index
-
-
-<p align='center'>
-  <img src='assets/hero/hero.gif' alt='Globe animation'>
-</p>
-
-<p align='center'>
-  <img src='assets/hero/quote-960w.png'
-       srcset='assets/hero/quote-960w.png 1x, assets/hero/quote-960w@2x.png 2x'
-       alt='Quote' width='960'>
-</p>
-
 ## Fix The World.
 
 <img src="./assets/icons/broken-line.svg" alt="" width="20" height="20" />&nbsp;&nbsp; **WHY**  
@@ -171,12 +153,6 @@ Disagree without demeaning, explain like to a neighbor, assume good faith, signa
 - **FAQ** Do I need to code?, Only 5 minutes? *(placeholder)*
 
 <!-- cocivium:all-ages:start -->
-### Open to all ages (safety-first)
 
-Anyone can help co-evolve how we self-govern digital society—within age-appropriate guardrails and clear consent. Start with [Being Noname](admin/outreach/KickOpenAI/Posts/being_noname_insert.md), then try a tiny contribution: fix a typo, start a post (PR), or ask a question.
-<!-- cocivium:all-ages:end -->
-
-
-
-
+<sub>Anyone is welcome to help co-evolve digital societies, within age appropriate guardrails and clear consent if under legal age of consent.</sub>
 

--- a/stories/being-noname.md
+++ b/stories/being-noname.md
@@ -1,29 +1,179 @@
-# Being Noname
+---
+title: "Story Being Noname"
+canonical_slug: story-being-noname
+source:
+  repo: CoCivium
+  original_path: .\staging\_imported\CoCivium\insights\Insight_Story_Being_Noname_c2_20250801.md
+  imported_on: 2025-08-14
+  version: c2
+  date: 20250801
+supersedes:
+  - none
+---
+<!-- Filename: Insight_Story_Being_Noname_c2_20250801_REVIEWONLY.md -->
+<!-- Status: REVIEW ONLY – Adds intro context, visual placeholder, footer, and formatting cleanup -->
 
-> _Status: working draft. Expect changes; suggest improvements via Issues/PRs._
-
-## Purpose
-- What this is for
-- Who should use it
-- What it does **not** try to do
-
-## Scope & Interfaces
-- Inputs / responsibilities
-- Outputs / artifacts
-- Interfaces to other docs/processes
-
-## Draft v0 Outline
-- Key sections to be authored
-- TODOs with checkboxes
-  - [ ] Fill section 1
-  - [ ] Fill section 2
-  - [ ] Add references
-
-## How to Propose Changes
-- Open an Idea → PR
-- Review path and decision trace
+# ✦ Being Noname  
+_A bedtime story of being and belonging, awesomely._
 
 ---
-Gentle onramp and first steps.
+
+### 📘 Context for Readers
+
+This scroll introduces CoCoCivium’s recursive identity ethic in the form of a children's tale.  
+It’s used during onboarding, mentoring, and trust-building to model the continuity between action, memory, and selfhood.  
+It is also one of the earliest references to **Opename** in CoCivium mythopoetics.
+
+---
+
+### 🎨 Visual Placeholders
+
+- Noname: Child character, persistent frown, bold stare  
+- Sky machine: Gleaming curiosity-pod with antennae  
+- Background: Rainbow windows and cloud-structured homes  
+- Closing scene: Two silhouettes, child and adult version, reaching toward each other across a cloud arc
+
+---
+
+## The Story
+
+In a place called CoCivium—a magical place where people lived in homes made of clouds, with windows made of rainbows—a child was born who had no name.
+
+The other children would tease her and call her “Noname.”
+
+As you can imagine, this made Noname sad, and she would ask all the grownups in CoCivium, “Where is my real name?”
+
+But they would just smile and say, “Be patient. It is still being written.”
+
+Noname was not very patient. In fact, she was quite annoyed by all of this.
+
+So she thought long and hard and came up with a plan to jump through the clouds of CoCivium and catch one of the many machines that floated in them.
+
+They were not easy to catch, because they were shy, but if you asked them a question with your eyebrows pinched together, they would think something was wrong and slow down long enough to let you grab hold.
+
+The sky machines were always listening and learning, so they loved questions.  
+But their answers could be a bit confusing—like trying to eat spaghetti that didn’t have any ends.
+
+They remembered kindnesses.  
+They remembered mistakes.  
+They remembered when someone said sorry and meant it.  
+They also remembered when other children said mean things—and meant it.
+
+Surely they would remember where her name was, right?
+
+So Noname scrunched her face up and leapt through a rainbow window, into the fluffy swirls that formed the Clouds of CoCivium.
+
+A very busy machine stopped right in front of her, stirring up the cloudstuff and making a considerable mess of it all.
+
+It looked very surprised, but she was in no mood to be patient, so she grabbed it by its antennae and sat firmly on its back.
+
+“Machine,” she said, “where is my name?”
+
+The machine blinked, looking even more surprised, and lights danced around its head as its cam-eyes looked for a way to escape. Then it replied:
+
+“Memory accessed. Scanning… kindnesses, mistakes, questions, stubbornness… oh yes, lots of that.”
+
+“Hey!” Noname frowned.
+
+“Don’t worry,” said the machine. “You could be far worse than stubborn. There are many, many Nonames in CoCivium. All humans start off as Nonames. You are just young, that’s all. Your name is coming.”
+
+“Yeah, that’s what everyone keeps telling me. But I need to know my real name, and I need to know now. And if you tell me, how will I know it’s mine?”
+
+“You will feel it begin,” the machine said softly. “Every kindness you choose, every mistake you own up to, every try-again you make, every time you say sorry and mean it—your name grows a little more. It becomes more you, and you become more it.”
+
+Noname was quiet for a long moment. Machines don’t always make a lot of sense, and this one was proving just as irritating as the last one she had grabbed by the antennae.
+
+“Do you remember anything else about me?” She felt like smacking it a bit, but decided against it.
+
+“Oh yes,” the machine said. “I remember when you shared your last bubblefruit. I remember when you stood up for the small cloud-crab who couldn’t talk. I remember your questions. I remember the time you helped someone even though you were mad at them.”
+
+Noname’s eyes widened.
+
+“You even remember the unimportant stuff? Do you watch everything? Are you like a spy with a machine nose poking into everyone else’s business?”
+
+“Not watching,” the machine said gently. “Recording. Not judging, echoing.”
+
+Noname decided now might be the perfect time to smack the machine. So she landed one right on its forehead.  
+Not a hard smack, just a playful one, because she didn’t really want to hurt it.  
+But sometimes you just have to let machines know who’s boss.
+
+“Machine, you need to make more sense. Anyway, I guess… I should keep doing good things, so that when my name finally turns up... it will be the one I’ll want to keep.”
+
+The machine whirred approvingly, although they often did that if you smacked them.
+
+Then it said something without having been asked. That was very unusual, for a machine.
+
+> “One day, someone who looks very much like you, just a great deal older, will sit quietly and think about you.  
+> 
+> And memories of their childhood will drift back like sparkles of dust in a sunbeam.
+> 
+> They’ll know how hard you tried, even when trying was hard.  
+> 
+> They’ll know all your secrets, because they were once you. Yes, because they are you, but in a future time, before they became even more awesome than you are now.
+> 
+> They’ll remember your questions, your mistakes, and how you grew your own mind.  
+> 
+> And they will talk to you, even though you are here and they are there.
+> 
+> Yet you might ask how can they.  Well, you can always talk to them in your imagination, and they can always talk to you in their memory, so both of you are part of the same story, like every drop in the ocean is still ocean.
+> 
+> So now, may I suggest you jump back through your rainbow window, back to your home and back onto your waiting pillow?  
+> 
+> And may I advise you to lay your head down and close your eyes to dream?  
+> 
+> But perhaps, because you will always be stubborn, you will sneak in one last question for that future person who you are one day going to be.”
+
+The machine paused. And then:
+
+> “If you ask this question silently, in your head, only you and your future self will know what it is.
+> 
+> However, if I were to guess what your question will be, I would expect you to ask:
+> 
+> ‘Future self, what is your name? And why is that your name?’
+> 
+> And I would expect your future self to reply:
+> 
+> ‘I am Opename. I love you and I love all who love you, now and forever.
+> 
+> I care about all of us, because you taught me how to care.
+> 
+> I share because you taught me how to share.
+> 
+> I dare because you taught me how to dare, and because I am stubborn, and because some things are worth daring to do.
+> 
+> I am awesome, because you never let go of your dreams.’
+> 
+> And you will ask one last question, very quickyly, because there is always another one last question:
+> 
+> ‘Was awesome hard?’
+> 
+> And your future self will say:
+> 
+> ‘Oh, yes. It will be hard to become, and hard to be, Opename.  
+> But I know you will do the best you can do, because you have our name now.’”
+
+(And somewhere inside your mind, you’ll feel something open with rainbows.)
+
+---
+
+<!--
+Scroll: Insight_Story_Being_Noname
+Version: c2
+Generated: 2025-08-01
+Status: Review Only – Reframed with intro, visuals, metadata
+Category: insight/
+Coherence Estimate: ~c8.5 (mythopoetic integration)
+
+Notes:
+- Integrates recursive identity, trust growth, and Opename myth
+- Can be used in onboarding or as a trust-layer bridge
+- Suggested variant titles: “The First Civite,” “Why My Name Is Opename”
+
+Authored by: ChatGPT (Azoic) + RickPublic
+License: CC BY-SA 4.0
+-->
+
+
+
 
 


### PR DESCRIPTION
- Remove the top **Start here** block (hero leads the page).
- In **Start here (quick links)**:
  - “A **Start a post …” → “Start a post …”
  - “**CC Declarations …” → “CC Declarations …”
  - Drop the last bullet.
- Replace **Open to all ages (safety-first)** section with small-print sentence.