### PR TITLE
tidy: minimal fixes + docs canon (250826-0408Z)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,13 @@
-*.md   text eol=lf
-*.yml  text eol=lf
-*.yaml text eol=lf
+*           text=auto eol=lf
+
+*.sh        text eol=lf
+*.ps1       text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf
+*.md        text eol=lf
+*.svg       text eol=lf
+*.json      text eol=lf
+
+*.png       -text
+*.gif       -text
+*.jpg       -text

--- a/docs/COAGENT-WORKFLOW-BASICS.md
+++ b/docs/COAGENT-WORKFLOW-BASICS.md
@@ -3,6 +3,6 @@
 - DO headers live **outside** code blocks:
   `# 🟢➕ DO <Letter> — YYMMDD-HHMMZ — Short title`
 
-- End-of-instruction demarcation: final line is a **timestamp-only** code fence:
+- Final line of a multi-step instruction is a **timestamp-only** code fence.
 
 - Colors: 🟢 safe/observe, 🟡 relax/toggle, 🟦 enforce, 🟥 risky/destructive, 🟫 optional.

--- a/docs/COAGENT-WORKFLOW-BASICS.md
+++ b/docs/COAGENT-WORKFLOW-BASICS.md
@@ -1,0 +1,8 @@
+# CoAgent Workflow Basics (DO➕ Canon)
+
+- DO headers live **outside** code blocks:
+  `# 🟢➕ DO <Letter> — YYMMDD-HHMMZ — Short title`
+
+- End-of-instruction demarcation: final line is a **timestamp-only** code fence:
+
+- Colors: 🟢 safe/observe, 🟡 relax/toggle, 🟦 enforce, 🟥 risky/destructive, 🟫 optional.


### PR DESCRIPTION
Stop .gitattributes parse error; add DO➕ canon stub; no renames yet.