### PR TITLE
ci: guard HTML/SVG phrasing

### DIFF
--- a/.github/workflows/phrasing-guard-assets.yml
+++ b/.github/workflows/phrasing-guard-assets.yml
@@ -1,0 +1,27 @@
+name: phrasing-guard-assets
+on:
+  pull_request:
+    paths:
+      - '**/*.html'
+      - '**/*.htm'
+      - '**/*.svg'
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.html'
+      - '**/*.htm'
+      - '**/*.svg'
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Block 'consent before coercion' in assets
+        run: |
+          set -e
+          echo "Scanning assets for disallowed phrase…"
+          if grep -RIni --include='*.html' --include='*.htm' --include='*.svg' \
+               --exclude-dir={.git,node_modules,dist,build,target,venv,.venv,vendor,coverage} \
+               'consent before coercion' .; then
+            echo "::error::Use 'consent not coercion' instead."; exit 1
+          fi


### PR DESCRIPTION
Block 'consent before coercion' in .html/.htm/.svg files.