### PR TITLE
docs(cc): add single-file CC Scroll

### DIFF
--- a/docs/cc/SCROLL.md
+++ b/docs/cc/SCROLL.md
@@ -1,0 +1,72 @@
+# Cognocarta Consenti — Scroll
+
+*Single continuous reading copy assembled from canonical parts.*
+*Last updated: 2025-08-28 04:01 -04:00*
+
+---
+
+<!-- Source: COGNOCARTA_CONSENTI.md -->
+
+# Cognocarta Consenti (CC) — v1 working draft
+
+## Preamble
+Purpose (plain language).
+
+## Principles
+- Consent before coercion  
+- Transparency & traceability  
+- Reversibility & error-correction  
+- Dignity, privacy, proportionality  
+
+## Rights
+- Short, testable rights.
+
+## Governance
+- Proposal → Review → Objections/Amend → Ratify → Record
+- Roles: Stewards (temporary), Reviewers, Observers.
+
+## Objections & Resolution
+- Categories, timeboxes, escalation, finality.
+
+## Amendments
+- Versioning & changelog discipline.
+
+## Implementation Notes
+- Trails = issues/PRs + commits. HumanGate ON.
+
+
+
+---
+
+<!-- Source: AMENDMENTS_LOG.md -->
+
+# Amendments Log
+| Date | Section | Change | Rationale | Link |
+|---|---|---|---|---|
+
+---
+
+<!-- Source: DECISION_FLOW.md -->
+
+# Decision Flow (text form)
+1. Draft → 2. Publish → 3. Collect objections  
+4. Address/Amend → 5. Ratify or Recycle → 6. Record trails
+
+---
+
+<!-- Source: GLOSSARY.md -->
+
+# Glossary (extended)
+- Congruence — short definition placeholder.
+- RepTag — short definition placeholder.
+- VoteVector — short definition placeholder.
+
+---
+
+<!-- Source: CC_SUPPORTING_DOCS.md -->
+
+# CC Supporting Docs
+- DECISION_FLOW.md — linear text flow
+- ROLES.md — concise role definitions (todo)
+- AMENDMENTS_LOG.md — table of changes
+- GLOSSARY.md — extended terms


### PR DESCRIPTION
Starts at CC preamble and appends supporting docs for continuous reading.