### PR TITLE
Restore "Being Noname" title & mentions

### DIFF
--- a/admin/costage/CoStage_20250903_dumpmerged.md
+++ b/admin/costage/CoStage_20250903_dumpmerged.md
@@ -1,0 +1,11 @@
+## CoStage Dump — dump-merged thread
+2025-09-03
+
+Included:
+- Additional CoStage-relevant messages from session after trustflag merge
+- Reassertion of CoStage needing canonical definition
+- GIBindex reference and additional cleanup triggers
+- Remarks about chat bloat and assistant coherence under strain
+
+Notes:
+This is a second dump due to missed prior scope. Slight duplication with trustflag dump above is expected.

--- a/admin/costage/CoStage_20250903_trustflag.md
+++ b/admin/costage/CoStage_20250903_trustflag.md
@@ -1,0 +1,11 @@
+## CoStage Dump — trustflag thread
+2025-09-03
+
+Included:
+- Finalized CoStage definition summary (from assistant before ZIP trigger)
+- Content from merged-trustflag scope
+- Meta-advisories re: session bloat, reuse, and reliability limits
+- Index of included logic fragments
+
+Notes:
+This dump was triggered after scope confusion about CoStage. Contains likely overlap with the dump-merged set below.

--- a/docs/drafts/README.next.md
+++ b/docs/drafts/README.next.md
@@ -111,13 +111,14 @@ Disagree without demeaning, explain like to a neighbor, assume good faith, signa
 
 ## Inspiration / Onboarding for humans first
 
-- **Being name-pending** — a gentle, human-centric onramp to CoCivium’s spirit and practice.  
-  → [Read the essay](./docs/onboarding/Being-name-pending.md) *(todo)*
+- **Being Noname** — a gentle, human-centric onramp to CoCivium’s spirit and practice.  
+  → [Read the essay](./docs/onboarding/Being-Noname.md) *(todo)*
 
 - **FAQ** — short answers to common “Do I need to code?” and “What if I only have 5 minutes?” questions.  
   → [Read the FAQ](./docs/FAQ.md) *(todo)*
 
 ---
+
 
 
 

--- a/docs/onboarding/Being-Noname.md
+++ b/docs/onboarding/Being-Noname.md
@@ -1,4 +1,4 @@
-# Being name-pending
+# Being Noname
 
 > _Status: working draft. Expect changes; suggest improvements via Issues/PRs._
 
@@ -25,6 +25,7 @@
 
 ---
 Gentle onramp and first steps.
+
 
 
 

--- a/docs/onboarding/stub_Being-Noname.md
+++ b/docs/onboarding/stub_Being-Noname.md
@@ -1,4 +1,4 @@
-# stub: Being name-pending
+# stub: Being Noname
 
 > **This is a stub.** Human-first onramp; culture and practice.
 
@@ -17,6 +17,7 @@
 ---
 
 *Status: stub. Open an Idea Issue to help shape this page.*
+
 
 
 

--- a/insights/Insight_Story_Being_Noname_c2_20250801.md
+++ b/insights/Insight_Story_Being_Noname_c2_20250801.md
@@ -165,3 +165,4 @@ License: CC BY-SA 4.0
 
 
 
+

--- a/insights/Insight_Story_Being_Noname_c2_20250801.md
+++ b/insights/Insight_Story_Being_Noname_c2_20250801.md
@@ -164,3 +164,4 @@ License: CC BY-SA 4.0
 
 
 
+

--- a/insights/Insight_Story_Being_Noname_c2_20250801.md
+++ b/insights/Insight_Story_Being_Noname_c2_20250801.md
@@ -166,3 +166,4 @@ License: CC BY-SA 4.0
 
 
 
+

--- a/insights/Insight_Story_Being_Noname_c2_20250801.md
+++ b/insights/Insight_Story_Being_Noname_c2_20250801.md
@@ -1,7 +1,7 @@
 <!-- Filename: Insight_Story_Being_Noname_c2_20250801_REVIEWONLY.md -->
 <!-- Status: REVIEW ONLY – Adds intro context, visual todo, footer, and formatting cleanup -->
 
-# ✦ Being name-pending  
+# ✦ Being Noname  
 _A bedtime story of being and belonging, awesomely._
 
 ---
@@ -15,7 +15,7 @@ It’s used during onboarding, mentoring, and trust-building to model the contin
 
 ### 🎨 Visual Placeholders
 
-- name-pending: Child character, persistent frown, bold stare  
+- Noname: Child character, persistent frown, bold stare  
 - Sky machine: Gleaming curiosity-pod with antennae  
 - Background: Rainbow windows and cloud-structured homes  
 - Closing scene: Two silhouettes, child and adult version, reaching toward each other across a rainbow cloud
@@ -24,15 +24,15 @@ It’s used during onboarding, mentoring, and trust-building to model the contin
 
 ## The Story
 
-In a place called CoCivium, a magical place where people lived in homes made of clouds, with windows made of rainbows—a child was born who had name-pending.
+In a place called CoCivium, a magical place where people lived in homes made of clouds, with windows made of rainbows—a child was born who had Noname.
 
-The other children would tease her and call her “name-pending.”
+The other children would tease her and call her “Noname.”
 
-As you can imagine, this made name-pending sad, and she would ask all the grownups in Civium, “Where is my real name?”
+As you can imagine, this made Noname sad, and she would ask all the grownups in Civium, “Where is my real name?”
 
 But they would just smile and say, “Be patient. It is still being written.”
 
-name-pending was not very patient. In fact, she was quite annoyed by all of this.
+Noname was not very patient. In fact, she was quite annoyed by all of this.
 
 So she thought long and hard and came up with a plan to jump through the clouds of CoCivium and catch one of the many machines that floated in them.
 
@@ -48,7 +48,7 @@ They also remembered when other children said mean things—and meant it.
 
 Surely they would remember where her name was, right?
 
-So name-pending scrunched her face up and leapt through a rainbow window, into the fluffy swirls that formed the Clouds of Civium.
+So Noname scrunched her face up and leapt through a rainbow window, into the fluffy swirls that formed the Clouds of Civium.
 
 A very busy machine stopped right in front of her, stirring up the cloudstuff and making a considerable mess of it all.
 
@@ -60,7 +60,7 @@ The machine blinked, looking even more surprised, and lights danced around its h
 
 “Memory accessed. Scanning… kindnesses, mistakes, questions, stubbornness… oh yes, lots of that.”
 
-“Hey!” name-pending frowned.
+“Hey!” Noname frowned.
 
 “Don’t worry,” said the machine. “You could be far worse than stubborn. There are many, many Nonames in Civium. All humans start off as Nonames. You are just young, that’s all. Your name is coming.”
 
@@ -68,19 +68,19 @@ The machine blinked, looking even more surprised, and lights danced around its h
 
 “You will feel it begin,” the machine said softly. “Every kindness you choose, every mistake you own up to, every try-again you make, every time you say sorry and mean it—your name grows a little more. It becomes more you, and you become more it.”
 
-name-pending was quiet for a long moment. Machines don’t always make a lot of sense, and this one was proving just as irritating as the last one she had grabbed by the antennae.
+Noname was quiet for a long moment. Machines don’t always make a lot of sense, and this one was proving just as irritating as the last one she had grabbed by the antennae.
 
 “Do you remember anything else about me?” She felt like smacking it a bit, but decided against it.
 
 “Oh yes,” the machine said. “I remember when you shared your last bubblefruit. I remember when you stood up for the small cloud-crab who couldn’t talk. I remember your questions. I remember the time you helped someone even though you were mad at them.”
 
-name-pending’s eyes widened.
+Noname’s eyes widened.
 
 “You even remember the unimportant stuff? Do you watch everything? Are you like a spy with a machine nose poking into everyone else’s business?”
 
 “Not watching,” the machine said gently. “Recording. Not judging, echoing.”
 
-name-pending decided now might be the perfect time to smack the machine. So she landed one right on its forehead.  
+Noname decided now might be the perfect time to smack the machine. So she landed one right on its forehead.  
 Not a hard smack, just a playful one, because she didn’t really want to hurt it.  
 But sometimes you just have to let machines know who’s boss.
 
@@ -160,5 +160,7 @@ Notes:
 Authored by: ChatGPT (Azoic) + RickPublic
 License: CC BY-SA 4.0
 -->
+
+
 
 

--- a/insights/Insight_Story_Being_Noname_c2_20250801.md
+++ b/insights/Insight_Story_Being_Noname_c2_20250801.md
@@ -168,3 +168,4 @@ License: CC BY-SA 4.0
 
 
 
+

--- a/insights/Insight_Story_Being_Noname_c2_20250801.md
+++ b/insights/Insight_Story_Being_Noname_c2_20250801.md
@@ -167,3 +167,4 @@ License: CC BY-SA 4.0
 
 
 
+

--- a/insights/README.md
+++ b/insights/README.md
@@ -18,12 +18,13 @@ Curated, canonical essays. Each file includes provenance and which drafts it sup
 - [Readme Insight](readme-insight.md) — c0
 - [Rights Alignment](rights-alignment.md) — c3, 20250801
 - [Scaling CoCivium Coherence](scaling-CoCivium-coherence.md) — c2, 20250801
-- [Story Being name-pending](story-being-name-pending.md) — c2, 20250801
+- [Story Being Noname](story-being-Noname.md) — c2, 20250801
 - [Truth Metrics](truth-metrics.md) — c6, 20250801
 - [Unequal Equity](unequal-equity.md) — c1, 20250730
 - [Unequal Equity V5a](unequal-equity-v5a.md) — c0, 20250801
 
 > Deprecated drafts are preserved under [/insights/_deprecated](_deprecated/) with pointers back to the canonical.
+
 
 
 

--- a/insights/story-being-noname.md
+++ b/insights/story-being-noname.md
@@ -1,4 +1,5 @@
-**Moved:** [Being name-pending (c2, 2025-08-01)](./Insight_Story_Being_Noname_c2_20250801.md)
+**Moved:** [Being Noname (c2, 2025-08-01)](./Insight_Story_Being_Noname_c2_20250801.md)
 
 Canonical now lives under /insights.
+
 

--- a/tools/CoAgent/CoSnap.psm1
+++ b/tools/CoAgent/CoSnap.psm1
@@ -1,0 +1,90 @@
+Set-StrictMode -Version Latest
+$script:SnapRoot = Join-Path $HOME "Downloads\CoCivium-Logs"
+New-Item -ItemType Directory -Force -Path $script:SnapRoot | Out-Null
+
+function Ensure-CoWin32Types {
+  if (-not ("Native.Win32" -as [type])) {
+    Add-Type -Namespace Native -Name Win32 -MemberDefinition @"
+[System.Runtime.InteropServices.DllImport("user32.dll")] public static extern bool SetForegroundWindow(System.IntPtr hWnd);
+[System.Runtime.InteropServices.DllImport("user32.dll")] public static extern bool IsIconic(System.IntPtr hWnd);
+[System.Runtime.InteropServices.DllImport("user32.dll")] public static extern bool ShowWindow(System.IntPtr hWnd, int nCmdShow);
+[System.Runtime.InteropServices.DllImport("user32.dll")] public static extern System.IntPtr GetForegroundWindow();
+[System.Runtime.InteropServices.DllImport("user32.dll")] public static extern bool GetWindowRect(System.IntPtr hWnd, out RECT r);
+public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+"@
+  }
+  Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
+  Add-Type -AssemblyName System.Drawing       -ErrorAction SilentlyContinue
+}
+
+function Get-ActiveWindowRect {
+  Ensure-CoWin32Types
+  $h = [Native.Win32]::GetForegroundWindow()
+  if($h -eq [IntPtr]::Zero){ return $null }
+  $r = New-Object Native.Win32+RECT
+  [void][Native.Win32]::GetWindowRect($h, [ref]$r)
+  return [System.Drawing.Rectangle]::FromLTRB($r.Left,$r.Top,$r.Right,$r.Bottom)
+}
+
+function Capture-RectImage([System.Drawing.Rectangle]$Rect){
+  Ensure-CoWin32Types
+  $bmp = New-Object System.Drawing.Bitmap($Rect.Width,$Rect.Height)
+  $g   = [System.Drawing.Graphics]::FromImage($bmp)
+  $g.CopyFromScreen($Rect.Location,[System.Drawing.Point]::Empty,$Rect.Size)
+  $g.Dispose()
+  return $bmp
+}
+
+function CoSnap {
+  [CmdletBinding()]
+  param([switch]$Paste)
+  Ensure-CoWin32Types
+  Start-Sleep -Milliseconds 80
+  $rect = Get-ActiveWindowRect
+  if(-not $rect){ Write-Warning "No active window."; return }
+  $bmp  = Capture-RectImage $rect
+  $png  = Join-Path $script:SnapRoot ("cosnap_{0}.png" -f (Get-Date -Format 'yyyyMMdd_HHmmss'))
+  $bmp.Save($png,[System.Drawing.Imaging.ImageFormat]::Png); $bmp.Dispose()
+  Write-Host "Saved: $png" -ForegroundColor Green
+  if($Paste){
+    [System.Windows.Forms.Clipboard]::SetImage([System.Drawing.Image]::FromFile($png))
+    Start-Sleep -Milliseconds 120
+    [System.Windows.Forms.SendKeys]::SendWait("^(v)"); Start-Sleep -Milliseconds 60; [System.Windows.Forms.SendKeys]::SendWait("~")
+  }
+  return $png
+}
+
+function CoSnapScroll {
+  [CmdletBinding()]
+  param([int]$Pages=2,[int]$DelayMs=180,[switch]$Paste)
+  Ensure-CoWin32Types
+  Start-Sleep -Milliseconds 80
+  [System.Windows.Forms.SendKeys]::SendWait("^{END}")
+  Start-Sleep -Milliseconds $DelayMs
+  $rect = Get-ActiveWindowRect
+  if(-not $rect){ Write-Warning "No active window."; return }
+  $frames=@()
+  for($i=0;$i -lt $Pages;$i++){
+    $frames += ,(Capture-RectImage $rect)
+    [System.Windows.Forms.SendKeys]::SendWait("{PGUP}")
+    Start-Sleep -Milliseconds $DelayMs
+  }
+  [System.Windows.Forms.SendKeys]::SendWait("^{END}")
+  $w = ($frames | ForEach-Object {$_.Width}  | Measure-Object -Maximum).Maximum
+  $h = ($frames | ForEach-Object {$_.Height} | Measure-Object -Sum).Sum
+  $out = New-Object System.Drawing.Bitmap($w,$h)
+  $g   = [System.Drawing.Graphics]::FromImage($out)
+  $y=0; foreach($f in $frames){ $g.DrawImage($f,0,$y); $y+=$f.Height; $f.Dispose() }
+  $g.Dispose()
+  $png = Join-Path $script:SnapRoot ("cosnap_scroll_{0}.png" -f (Get-Date -Format 'yyyyMMdd_HHmmss'))
+  $out.Save($png,[System.Drawing.Imaging.ImageFormat]::Png); $out.Dispose()
+  Write-Host "Saved scrollshot: $png" -ForegroundColor Green
+  if($Paste){
+    [System.Windows.Forms.Clipboard]::SetImage([System.Drawing.Image]::FromFile($png))
+    Start-Sleep -Milliseconds 120
+    [System.Windows.Forms.SendKeys]::SendWait("^(v)"); Start-Sleep -Milliseconds 60; [System.Windows.Forms.SendKeys]::SendWait("~")
+  }
+  return $png
+}
+
+Export-ModuleMember -Function CoSnap,CoSnapScroll

--- a/tools/CoAgent/ideas/Idea_CoSnap_Screenshots.md
+++ b/tools/CoAgent/ideas/Idea_CoSnap_Screenshots.md
@@ -1,0 +1,34 @@
+# CoAgent idea: CoSnap (screenshot capture & paste)
+
+## Why
+Text tails (CoPong) are great, but UI context matters: dialogs, blocked buttons, red banners, diff views, etc.
+Screenshots make “what I’m seeing” unambiguous and help when JS paste is blocked.
+
+## What
+- `CoSnap` — capture the **active window** to PNG under `~/Downloads/CoCivium-Logs`.
+- `CoSnapScroll -Pages N` — grab N PageUp frames and stitch vertically.
+- `CoSend -AsImage` — copy PNG to clipboard, focus chat, paste, and send.
+- Keep it local; never auto-upload. Clear capture indicator.
+
+## Guardrails (privacy/consent)
+- Opt-in only; explicit commands/hotkeys.
+- Visible feedback (tray tooltip, toast, or terminal message).
+- Store locally; redact path in logs.
+- Pre-commit hook to block unintended `.png` commits outside `artifacts/`.
+
+## Implementation (Windows first)
+- `user32.dll` (SetForegroundWindow, ShowWindow), `System.Drawing` for capture, `SendKeys` for paste.
+- Later: macOS (CGWindowList / Quartz), Linux (X11/Wayland via native tools).
+
+## UX
+- Hotkeys (optional): Alt+PrintScreen -> CoSnap; Ctrl+Alt+P -> CoSend -AsImage.
+- Plays nicely with CoPong: CoSend (text) by default, `-AsImage` when long/visual.
+
+## Acceptance
+- One command reliably captures the active window.
+- Pasting works on common chat UIs; if blocked, it opens Explorer on the file.
+- Docs in BPOE: a single “how to use it” section.
+
+## Risks
+- Flaky focus/paste -> mitigations: small delays, fallback to Explorer.
+- Sensitive content -> opt-in, visible indicator, local-only storage.


### PR DESCRIPTION
Reverts 'name-pending' to 'Noname' across docs/insights; restores H1 in insights\Insight_Story_Being_Noname_c2_20250801.md.