### PR TITLE
chore: unify codespell wordlists + enforce LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,7 @@
 *.jpg binary
 *.gif binary
 *.zip binary
+
+# Enforce LF — added 2025-09-04T23:20:03
+*.md text eol=lf
+*.ps1 text eol=lf

--- a/admin/costage/CoStage_20250903_dumpmerged.md
+++ b/admin/costage/CoStage_20250903_dumpmerged.md
@@ -1,0 +1,11 @@
+## CoStage Dump — dump-merged thread
+2025-09-03
+
+Included:
+- Additional CoStage-relevant messages from session after trustflag merge
+- Reassertion of CoStage needing canonical definition
+- GIBindex reference and additional cleanup triggers
+- Remarks about chat bloat and assistant coherence under strain
+
+Notes:
+This is a second dump due to missed prior scope. Slight duplication with trustflag dump above is expected.

--- a/admin/costage/CoStage_20250903_trustflag.md
+++ b/admin/costage/CoStage_20250903_trustflag.md
@@ -1,0 +1,11 @@
+## CoStage Dump — trustflag thread
+2025-09-03
+
+Included:
+- Finalized CoStage definition summary (from assistant before ZIP trigger)
+- Content from merged-trustflag scope
+- Meta-advisories re: session bloat, reuse, and reliability limits
+- Index of included logic fragments
+
+Notes:
+This dump was triggered after scope confusion about CoStage. Contains likely overlap with the dump-merged set below.


### PR DESCRIPTION
Consolidates ignore-words and enforces LF (.gitattributes).  No functional changes.