### PR TITLE
chore: enforce LF via .gitattributes (rev2)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,5 @@
 [codespell]
 skip = *.png,*.jpg,*.jpeg,*.svg,*.ico,*.pdf,site/assets/**,_site/**
-ignore-words = .codespell.words
+ignore-words=tools/lint/codespell.words.txt
+
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 *.yml text eol=lf
 *.yaml text eol=lf
 *.md text eol=lf
+
+# Enforce LF — 2025-09-04T23:54:31
+*.md  text eol=lf

--- a/tools/lint/codespell.words.txt
+++ b/tools/lint/codespell.words.txt
@@ -1,0 +1,21 @@
+antifragile
+Auto-merge
+automerge
+co-evolution
+cocivai
+CoCivium
+coevolve
+CoNudge
+CoPong
+CoSnap
+hashable
+ignore-words = .codespell.words
+Markdownlint
+mermaid
+name-pending
+non-humans
+Noname
+nonhuman
+skip = *.png,*.jpg,*.jpeg,*.svg,*.ico,*.pdf,site/assets/**,_site/**
+steward
+Yamllint


### PR DESCRIPTION
Follow-up to #350 (conflict-resolved reseed on current main).
- Enforce LF via .gitattributes
- Point .codespellrc to unified words list
- Keep admin bypass ON by policy

Original PR body for context:

Add/ensure LF enforcement for text/md/ps1.