### PR TITLE
docs(bpoe): mitigation — advisory-green but BLOCKED (mergeability cache)

### DIFF
--- a/admin/bpoe/_index.md
+++ b/admin/bpoe/_index.md
@@ -4,5 +4,7 @@ This area collects operational learnings we want to keep handy.
 
 ## Mitigations
 * [Mitigations Index](admin/bpoe/mitigations/_index.md)
+* [Advisory checks green, PR still BLOCKED (mergeability cache) — cookbook](admin/bpoe/mitigations/2025-09-05_advisory-green-but-blocked_fix.md)
+* [Advisory checks green, PR still BLOCKED (mergeability cache) — cookbook](admin/bpoe/mitigations/2025-09-05_advisory-green-but-blocked.md)
 * [Mitigation: Auto-merge **BLOCKED** with advisory failures (GitHub mergeability cache & required checks mapping)](admin/bpoe/mitigations/2025-09-05_mergeability-cache-and-checks.md)
 

--- a/admin/bpoe/mitigations/2025-09-05_advisory-green-but-blocked_fix.md
+++ b/admin/bpoe/mitigations/2025-09-05_advisory-green-but-blocked_fix.md
@@ -1,0 +1,25 @@
+# Advisory checks green, PR still BLOCKED (mergeability cache) — cookbook
+
+**Symptom:** PR shows `mergeStateStatus=BLOCKED` even though the _required_ checks are green.  
+**Cause:** GitHub’s mergeability cache can report `statusCheckRollup.state=FAILURE` because *advisory* jobs (non-required) are included in the rollup.
+
+## What “good” looks like
+Branch protection:
+- `required_status_checks.checks` pins:
+  - `safety-gate/gate`
+  - `readme-smoke/check`
+- `strict=true`
+- **Admin bypass ON** (enforce_admins=false) by policy.
+
+CI:
+- Required jobs named exactly as above (produce those contexts).
+- Advisory jobs may fail (`continue-on-error: true`) without blocking.
+
+## Fix sequence (prefer order)
+1) Push a no-op commit (cache nudge)  
+2) Close → Reopen PR (hard refresh)  
+3) Reseed as a fresh PR  
+4) Manual merge (admin) only if required checks are green and cache is stale  
+5) Re-assert protections using `checks` (not `contexts`)
+
+_This doc is part of BPOE “Known Issues & Mitigations”._

--- a/admin/bpoe/mitigations/_index.md
+++ b/admin/bpoe/mitigations/_index.md
@@ -3,5 +3,7 @@
 Single-topic write-ups of problems we hit and how we fixed or prevented them.
 
 * [Mitigations Index](_index.md)
+* [Advisory checks green, PR still BLOCKED (mergeability cache) — cookbook](2025-09-05_advisory-green-but-blocked_fix.md)
+* [Advisory checks green, PR still BLOCKED (mergeability cache) — cookbook](2025-09-05_advisory-green-but-blocked.md)
 * [Mitigation: Auto-merge **BLOCKED** with advisory failures (GitHub mergeability cache & required checks mapping)](2025-09-05_mergeability-cache-and-checks.md)
 


### PR DESCRIPTION
Adds cookbook + regenerates BPOE indexes.