### PR TITLE
docs(CC): add PREAMBLE anchored to Core Assumption

### DIFF
--- a/docs/cc/PREAMBLE.md
+++ b/docs/cc/PREAMBLE.md
@@ -1,11 +1,7 @@
-# Cognocarta Consenti — Preamble
+# CC Preamble — Philosophical Anchor
 
-Civium favors **convergence over control**. CC is the consent-centered
-through-line: language, structures, and scrolls we can refine together.
+This Operating Constitution presumes the **Core Assumption**: that purpose itself evolves.  
+Accordingly, our procedures prefer **congruence**—the preservation and empowerment of diverse intelligences—and reject domination as brittle.  
+Where rules conflict, choose the option that increases the longevity and number of cooperating intelligences **without enabling coercion**.
 
-See:
-- Poetics (curated): [docs/cc/00-Poetics/](00-Poetics/)
-- Scroll (working text): [docs/cc/10-Scroll/](10-Scroll/)
-
-_Last updated: 2025-08-26_
-
+> See: [Core Assumption](../philosophy/Core_Assumption.md) · [Explained](../philosophy/Core_Assumption_Explained.md)

--- a/docs/cc/README.md
+++ b/docs/cc/README.md
@@ -1,7 +1,9 @@
+> **Start Here:** Read the [CC Preamble](PREAMBLE.md) — the philosophical anchor derived from the Core Assumption.
 # CC Hub
 - **Cognocarta Consenti (CC):** [COGNOCARTA_CONSENTI.md](./COGNOCARTA_CONSENTI.md)
 - Supporting: [CC_SUPPORTING_DOCS.md](./CC_SUPPORTING_DOCS.md), [DECISION_FLOW.md](./DECISION_FLOW.md), [AMENDMENTS_LOG.md](./AMENDMENTS_LOG.md), [GLOSSARY.md](./GLOSSARY.md)
 
 
 > **Philosophical Anchor:** See [Core Assumption](../philosophy/Core_Assumption.md) and [Explained](../philosophy/Core_Assumption_Explained.md).
+
 


### PR DESCRIPTION
Introduces **docs/cc/PREAMBLE.md** and surfaces it from the CC index.