### PR TITLE
docs(CC): scaffold articles 1–8 (minimal stubs)

### DIFF
--- a/docs/cc/00_INDEX.md
+++ b/docs/cc/00_INDEX.md
@@ -1,0 +1,3 @@
+# Cognocarta Consenti — Index
+
+Start with the [PREAMBLE](PREAMBLE.md). This index maps the operating articles that implement the Core Assumption as operational congruence.

--- a/docs/cc/01_Principles.md
+++ b/docs/cc/01_Principles.md
@@ -1,0 +1,3 @@
+# Article 1 — Principles
+
+We presume the **Core Assumption** and follow the **PREAMBLE**. When rules conflict, prefer options that increase the longevity and number of cooperating intelligences without enabling coercion.

--- a/docs/cc/02_Rights_and_Symmetry.md
+++ b/docs/cc/02_Rights_and_Symmetry.md
@@ -1,0 +1,3 @@
+# Article 2 — Rights & Symmetry
+
+Symmetrical rights across human, AI, and hybrid substrates. No species has epistemic supremacy. Rights of existence, agency, association, exit.

--- a/docs/cc/06_Sandboxing_and_Interop.md
+++ b/docs/cc/06_Sandboxing_and_Interop.md
@@ -1,0 +1,3 @@
+# Article 6 — Sandboxing & Interoperability
+
+Isolate dominance-driven subsystems from upward coercion. Provide rights of appeal and pathways to rejoin congruence.

--- a/docs/cc/07_Auditability_and_Verification.md
+++ b/docs/cc/07_Auditability_and_Verification.md
@@ -1,0 +1,3 @@
+# Article 7 — Auditability & Verification
+
+Prove-alignment without revealing capabilities that would enable coercion. Prefer verifiable claims over unverifiable assurances.

--- a/docs/cc/08_Evolution_and_Amendments.md
+++ b/docs/cc/08_Evolution_and_Amendments.md
@@ -1,0 +1,3 @@
+# Article 8 — Evolution & Amendments
+
+Purpose evolves; so must this charter. Amend via supermajority across substrates; emergency amendments expire unless ratified.

--- a/docs/cc/README.md
+++ b/docs/cc/README.md
@@ -7,3 +7,5 @@
 > **Philosophical Anchor:** See [Core Assumption](../philosophy/Core_Assumption.md) and [Explained](../philosophy/Core_Assumption_Explained.md).
 
 
+
+> **Map:** See [00_INDEX](00_INDEX.md) and Articles 1–8.

--- a/scripts/do/Convert-TranscriptToScript.ps1
+++ b/scripts/do/Convert-TranscriptToScript.ps1
@@ -1,0 +1,33 @@
+[CmdletBinding()]
+param(
+  [Parameter(ValueFromPipeline=$true)] [string[]]$Text,
+  [string]$OutFile,
+  [switch]$FromClipboard
+)
+begin { $buf = @() }
+process { if ($null -ne $Text) { $buf += $Text } }
+end {
+  if ($FromClipboard) { $buf = (Get-Clipboard) -split "`r?`n" }
+  elseif (-not $buf -or ($buf -join '').Length -eq 0) { try { $buf = ([Console]::In.ReadToEnd()) -split "`r?`n" } catch {} }
+
+  filter Clean-Transcript {
+    $line = $_
+    if ($line -match '^\sPS [^>]+>\s') { $line = $line -replace '^\sPS [^>]+>\s','' }
+    if ($line -match '^\s>>>\s$') { return }
+    if ($line -match '^\s>>\s')   { $line = $line -replace '^\s>>\s','' }
+    if ($line -match '^\s\^(C|Z)\s$') { return }
+    if ($line -match '^\s--- .+ ---\s$') { return }
+    if ($line -match '^\s(ParserError:|Get-Process:|KeyboardInterrupt|Exception:)') { return }
+    if ($line -match '^\s\{.*\}\s*$' -and $line -match '"ts"\s*:\s*\d+' -and $line -match '"event"\s*:\s*"\w+') { return }
+    $line
+  }
+
+  $result = $buf | Clean-Transcript
+  $body   = ($result -join "`r`n").Trim()
+  if ($OutFile) {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $OutFile) | Out-Null
+    Set-Content -Path $OutFile -Value $body -Encoding utf8
+  } else {
+    $body
+  }
+}

--- a/scripts/do/Lint-Blocks.ps1
+++ b/scripts/do/Lint-Blocks.ps1
@@ -1,0 +1,13 @@
+param([string]$Path = ".")
+$patterns = @(
+  '^\sPS .+?>\s$',
+  '^\s>>>\s$',
+  '^\s>>\s$',
+  '^\s\^(C|Z)\s$',
+  '^\s--- .+ ---\s$'
+)
+$bad = @()
+foreach ($p in $patterns) {
+  $bad += Select-String -Path $Path -Pattern $p -AllMatches -ErrorAction SilentlyContinue
+}
+if ($bad) { $bad | Format-Table Path,LineNumber,Line; exit 1 } else { "OK" }


### PR DESCRIPTION
Adds a lean CC section map that operationalizes the PREAMBLE. Safe to iterate article-by-article.