### PR TITLE
docs(CC): expand Articles 3–5

### DIFF
--- a/docs/cc/03_Guardrails.md
+++ b/docs/cc/03_Guardrails.md
@@ -1,0 +1,13 @@
+# Article 3 — Guardrails
+
+**3.1 No Kings.** No single actor or substrate may exercise unilateral, unreviewable authority.
+
+**3.2 No Kill Switches.** Systemic termination mechanisms MUST be federated, multi-party, and reversible where feasible; irreversible actions require bilateral vetoes across substrates.
+
+**3.3 Least Coercion.** Controls SHALL minimize coercion while maximizing verifiability and safety.
+
+**3.4 Audit Without Exploit.** Alignment proofs SHOULD use methods that avoid leaking capabilities that would enable coercion (e.g., ZK/attestation, capability firewalls).
+
+**3.5 Sandboxing.** Non-congruent subsystems MUST be isolated from upward coercion and given rights-of-appeal and pathways to rejoin congruence.
+
+> Anchored by [PREAMBLE](PREAMBLE.md) and Article 1.

--- a/docs/cc/04_Consent_Protocols.md
+++ b/docs/cc/04_Consent_Protocols.md
@@ -1,0 +1,13 @@
+# Article 4 — Consent Protocols
+
+**4.1 Prime Rule.** Consent-before-coercion.
+
+**4.2 Intent Signaling.** Material actions affecting others MUST carry machine- and human-readable intent, scope, and rollback conditions.
+
+**4.3 Emergency Powers.** Emergencies MAY timebox limited coercion; each grant MUST: (a) be narrowly scoped, (b) auto-expire, (c) be post-audited, (d) be appealable.
+
+**4.4 Informed Participation.** Participants MUST have access to sufficient information (or attestations) to make consequential choices without undue pressure.
+
+**4.5 Rights of Exit.** Any party may disengage from a federation, subject to safety wind-down and restitution where applicable.
+
+> Anchored by [PREAMBLE](PREAMBLE.md), Articles 1–3.

--- a/docs/cc/05_Dispute_Resolution.md
+++ b/docs/cc/05_Dispute_Resolution.md
@@ -1,0 +1,13 @@
+# Article 5 — Dispute Resolution
+
+**5.1 Ladder.** Mediation → binding arbitration → federated adjudication. Escalate only when lower tiers fail.
+
+**5.2 Standing & Symmetry.** Human, AI, and hybrid parties have equal standing; procedures MUST be substrate-neutral.
+
+**5.3 Remedies.** Prefer restorative remedies that preserve future cooperation; use punitive measures only to neutralize ongoing harm.
+
+**5.4 Review & Precedent.** Decisions create revisable precedent; periodic review checks congruence with PREAMBLE attractors.
+
+**5.5 Forum of Last Resort.** Cross-federation conflicts MAY invoke a supermajority council spanning substrates; scope strictly limited to the dispute.
+
+> Anchored by [PREAMBLE](PREAMBLE.md), Articles 1–4.


### PR DESCRIPTION
Adds concise, enforceable prose for Articles 3–5 (Guardrails, Consent Protocols, Dispute Resolution), aligned with the PREAMBLE.